### PR TITLE
Create json output file if needed

### DIFF
--- a/src/save_jsonl.rs
+++ b/src/save_jsonl.rs
@@ -13,7 +13,7 @@ pub fn save_data_as_jsonl(path: &str, data: &[HashMap<String, f64>]) -> std::io:
         return Ok(());
     }
 
-    let mut file = File::options().append(true).open(path)?;
+    let mut file = File::options().append(true).create(true).open(path)?;
 
     for record in data {
         let json = serde_json::to_string(&record)?;


### PR DESCRIPTION
Fix error for the case when json file specified as output destination doesn't exist

```
thread 'main' panicked at src/main.rs:142:64:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
